### PR TITLE
Minor changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,7 +177,7 @@ pyrightconfig.json
 
 nina-python-init.py
 info_proj.txt
-lightning_lots/
+lightning_logs/
 config.yaml
 notebooks/
 .vscode/

--- a/src/dataset/segmentation_dataset.py
+++ b/src/dataset/segmentation_dataset.py
@@ -45,9 +45,9 @@ class SegmentationDataset(Dataset):
             mask = augmented["mask"]
 
             # Convert img and mask to torch tensors
-        img = torch.tensor(img, dtype=torch.float32)
-        mask = torch.tensor(mask, dtype=torch.long)
-
+        img = img.clone().detach().float()
+        mask = mask.clone().detach().long()
+        
         return img, mask
 
 

--- a/src/dataset/segmentation_dataset.py
+++ b/src/dataset/segmentation_dataset.py
@@ -58,6 +58,7 @@ def get_data_loaders(
     resize_transform,
     batch_size=8,
     val_split=0.2,
+    num_workers=8,
 ):
     image_paths = sorted(glob.glob(image_dir + "/*.png"))
     mask_paths = sorted(glob.glob(mask_dir + "/*.tif"))
@@ -83,10 +84,10 @@ def get_data_loaders(
 
     # Create DataLoaders
     train_loader = torch.utils.data.DataLoader(
-        train_dataset, batch_size=batch_size, shuffle=True
+        train_dataset, batch_size=batch_size, shuffle=True, num_workers=num_workers
     )
     val_loader = torch.utils.data.DataLoader(
-        val_dataset, batch_size=batch_size, shuffle=False
+        val_dataset, batch_size=batch_size, shuffle=False, num_workers=num_workers
     )
 
     return train_loader, val_loader

--- a/src/train.py
+++ b/src/train.py
@@ -102,6 +102,7 @@ def train(cfg):
         batch_size=cfg["BATCH_SIZE"],
         albumentations_transform=albumentations_transform,
         resize_transform=resize_transform,
+        num_workers=cfg["NUM_WORKERS"],
     )
 
     num_classes = cfg["NUM_CLASSES"]

--- a/src/train.py
+++ b/src/train.py
@@ -15,6 +15,7 @@ from torchmetrics.classification import MulticlassJaccardIndex
 from dataset.segmentation_dataset import get_data_loaders
 from utils.transforms import albumentations_transform, resize_transform
 
+torch.backends.cudnn.benchmark = True
 
 def get_deeplabv3_model(num_classes):
     model = models.deeplabv3_resnet50(weights="COCO_WITH_VOC_LABELS_V1")


### PR DESCRIPTION
- Fix typo in the `.gitignore` 😸 
- Add new config parameter for `NUM_WORKERS`, its used in the dataloader for letting it know how many cores we have available and enables parallel data loading. Basically making training go brrr. To find number of available cores do `nproc` in the bash-terminal.
- Enable cudnn.benchmark 👓 